### PR TITLE
Implemented obtainable enemy item drops

### DIFF
--- a/lib/game/entities/abstractities/base_enemy.js
+++ b/lib/game/entities/abstractities/base_enemy.js
@@ -582,6 +582,5 @@ ig.module(
             this.turnUsed = true;
             console.log(this.name + ' has been defeated.');
         }
-
     })
 });

--- a/lib/game/entities/enemies/practice_dummy.js
+++ b/lib/game/entities/enemies/practice_dummy.js
@@ -33,7 +33,7 @@ ig.module(
 
             // Items
             this.item[0] = ig.game.itemCatalog.axe1;  this.item_uses[0] = this.item[0].uses;
-            this.item[1] = ig.game.itemCatalog.sword10;  this.item_uses[1] = this.item[1].uses;
+            //this.item[1] = null;  this.item_uses[1] = this.item[1].uses;
             //this.item[2] = null;  this.item_uses[2] = this.item[2].uses;
             //this.item[3] = null;  this.item_uses[3] = this.item[3].uses;
             //this.item[4] = null;  this.item_uses[4] = this.item[4].uses;

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -819,39 +819,7 @@ ig.module(
                     }
                 }
             }
-
-            /* Enemy Item Drops - tentative
-
-            if(this.targetedUnit._killed && this.targetedUnit.unitType === 'enemy') {
-                var numEmpSlots = 0;
-                var freeSlot = 0;
-
-                for(var i = 0; i < this.units[this.activeUnit].item.length; i++) {
-
-                    if(this.units[this.activeUnit].item[i] === null){
-                        freeSlot = i;
-                        numEmpSlots++;
-                    }
-                }
-
-                if(numEmpSlots > 0) {
-
-                        for (var j = 1; j < this.targetedUnit.item.length; j++){ 
-
-                            if(this.targetedUnit.item[j] !== null){
-
-                                this.units[this.activeUnit].item[freeSlot] = this.targetedUnit.item[j];
-                            }
-
-                            else break;
-                        }
-                    }
-
-                else break;
-                }*/
-            
-
-                    
+       
             // Menu escape and clicked unit deselection during player's turn
             if(ig.input.pressed('escape') || this.units[this.activeUnit].unitType !== 'player') {
                 if(this.clickedUnit !== null && this.clickedUnit.unitType === 'player' && this.clickedUnit.vel.x === 0 && this.clickedUnit.vel.y === 0) {


### PR DESCRIPTION
-Added obtainable enemy item drops upon death:
When killed by a player unit, the enemy unit's equipped item will be moved to active player unit's inventory provided the player unit has free slots.

-Added hasSlots function:
returns true if unit has free space in inventory, otherwise returns false

-Added freeSlot function:
returns the first index of unit inventory that is free.

-Hero no longer starts with a full inventory for the sake of this feature.
