### PR TITLE
Implemented player phase modal, as well as some bug fixes

### DIFF
--- a/lib/game/entities/abstractities/base_enemy.js
+++ b/lib/game/entities/abstractities/base_enemy.js
@@ -144,7 +144,7 @@ ig.module(
             this.parent();
 
             // Only compute path if this unit is the active unit
-            if(ig.game.units[ig.game.activeUnit] === this) {
+            if(ig.game.units[ig.game.activeUnit] === this && ig.game.battleState != 'enemy_phase') {
                 // Check if this unit moved for this turn
                 if(!this.turnUsed) {
                     // Visual delay between generating path and moving unit along path

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -522,7 +522,8 @@ ig.module(
             // End health border/background ------------------------------------
 
             // Begin selectable action tiles -----------------------------------
-            if((typeof ig.game.units !== 'undefined' && ig.game.units[ig.game.activeUnit] === this && !this.turnUsed && this.idleTimer.delta() > 0.2) && ig.game.clickedUnit === this) {
+            if((typeof ig.game.units !== 'undefined' && ig.game.units[ig.game.activeUnit] === this && !this.turnUsed && this.idleTimer.delta() > 0.2) && ig.game.clickedUnit === this
+                && ig.game.displayedTurnModal === true) {
                 var i, j, radius, range,
                     ctx = ig.system.context;
 

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -245,7 +245,9 @@ ig.module(
                                 }*/
 
                                 // Wait for user's input (mouse)
-                                if(this.pointer.isLeftClicking) {
+                                // Also, we check if the selected tile doesn't have a unit on it
+                                if(this.pointer.isLeftClicking && ig.game.hoveredUnit === null) {
+                                    // console.log(ig.game.hoveredUnit);
                                     // Check if pointer is within this unit's reachable distance this turn
                                     var unit_pos = ig.global.alignToGrid(this.pos.x + ig.global.tilesize / 2, this.pos.y + ig.global.tilesize / 2);
                                     var ptr_pos = ig.global.alignToGrid(this.pointer.pos.x, this.pointer.pos.y);

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -246,7 +246,7 @@ ig.module(
 
                                 // Wait for user's input (mouse)
                                 // Also, we check if the selected tile doesn't have a unit on it
-                                if(this.pointer.isLeftClicking && ig.game.hoveredUnit === null && ig.game.displayedTurnModal === true) {
+                                if(this.pointer.isLeftClicking && ig.game.hoveredUnit === null && ig.game.displayedPlayerPhaseModal === true) {
                                     // console.log(ig.game.hoveredUnit);
                                     // Check if pointer is within this unit's reachable distance this turn
                                     var unit_pos = ig.global.alignToGrid(this.pos.x + ig.global.tilesize / 2, this.pos.y + ig.global.tilesize / 2);
@@ -523,7 +523,7 @@ ig.module(
 
             // Begin selectable action tiles -----------------------------------
             if((typeof ig.game.units !== 'undefined' && ig.game.units[ig.game.activeUnit] === this && !this.turnUsed && this.idleTimer.delta() > 0.2) && ig.game.clickedUnit === this
-                && ig.game.displayedTurnModal === true) {
+                && ig.game.displayedPlayerPhaseModal === true) {
                 var i, j, radius, range,
                     ctx = ig.system.context;
 

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -246,7 +246,7 @@ ig.module(
 
                                 // Wait for user's input (mouse)
                                 // Also, we check if the selected tile doesn't have a unit on it
-                                if(this.pointer.isLeftClicking && ig.game.hoveredUnit === null) {
+                                if(this.pointer.isLeftClicking && ig.game.hoveredUnit === null && ig.game.displayedTurnModal === true) {
                                     // console.log(ig.game.hoveredUnit);
                                     // Check if pointer is within this unit's reachable distance this turn
                                     var unit_pos = ig.global.alignToGrid(this.pos.x + ig.global.tilesize / 2, this.pos.y + ig.global.tilesize / 2);

--- a/lib/game/entities/misc/pointer.js
+++ b/lib/game/entities/misc/pointer.js
@@ -101,9 +101,9 @@ ig.module(
             this.parent(other);
 
             // User is clicking and the 'other' entity and has a clicked() method
-            if(this.isLeftClicking && typeof other.leftClicked === 'function')
+            if(this.isLeftClicking && typeof other.leftClicked === 'function' && other.unitType != 'enemy')
                 other.leftClicked();
-            if(this.isRightClicking && typeof other.rightClicked === 'function')
+            if(this.isRightClicking && typeof other.rightClicked === 'function' && other.unitType != 'enemy')
                 other.rightClicked();
         }
     }); // End EntityPointer

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -524,7 +524,9 @@ ig.module(
                 // Increase turn counter if active unit is main player (before main player moves)
                 if(this.units[this.activeUnit] instanceof ig.global.EntityHero) {
                     this.turn_counter++;
+                    // A new turn is starting, so we need to re-draw the "Player Phase" modal. 
                     this.displayedTurnModal = false;
+                    // Reset the timer which governs how long the modal is displayed. 
                     this.phaseTimer.reset();
                     console.log('Battle currently in turn ' + this.turn_counter);
                 }

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -410,6 +410,7 @@ ig.module(
             // Initialize timers
             this.atkAnimTimer = new ig.Timer();
             this.phaseTimer = new ig.Timer(1);
+            this.enemyPhaseTimer = new ig.Timer(1);
 
             this.screenFadeOut = new ig.ScreenFader({
                 fade: 'out',
@@ -510,10 +511,15 @@ ig.module(
             this.parent();
 
             var i, slot;
-
             // Have we displayed the player phase modal for the beginning of the turn?
             if(this.displayedPlayerPhaseModal === false){
                 this.battleState = 'player_phase';
+            }
+
+            if(this.units[this.activeUnit].unitType === 'enemy' && this.displayedEnemyPhaseModal === false){
+                // console.log("Enemy is currently moving");
+                this.enemyPhaseTimer.reset();
+                this.battleState = 'enemy_phase';
             }
 
             // Handle unit movement order
@@ -521,12 +527,15 @@ ig.module(
                 var u;
 
                 this.activeUnit = (this.activeUnit + 1) % this.units.length;
+                // console.log(this.displayedEnemyPhaseModal);
 
                 // Increase turn counter if active unit is main player (before main player moves)
                 if(this.units[this.activeUnit] instanceof ig.global.EntityHero) {
                     this.turn_counter++;
                     // A new turn is starting, so we need to re-draw the "Player Phase" modal. 
                     this.displayedPlayerPhaseModal = false;
+                    // A new turn is starting, we need to re-draw the "Enemy phase" modal.
+                    this.displayedEnemyPhaseModal = false; 
                     // Reset the timer which governs how long the modal is displayed. 
                     this.phaseTimer.reset();
                     console.log('Battle currently in turn ' + this.turn_counter);
@@ -1851,6 +1860,7 @@ ig.module(
             
             if(this.battleState === 'player_phase' && this.displayedPlayerPhaseModal === false){
                 // Timer is running, draw modal
+                // console.log(this.phaseTimer.delta());
                 if(this.phaseTimer.delta() < 0){
                     this.playerPhaseModal.draw(0, 250);
                 }
@@ -1858,9 +1868,23 @@ ig.module(
                     // We finished drawing, reset states
                     this.battleState = null;
                     this.displayedPlayerPhaseModal = true;
-                    // Reset the timer for the next time
                 }
             }
+
+            if(this.battleState === 'enemy_phase' && this.displayedEnemyPhaseModal === false){
+                // console.log(this.enemyPhaseTimer.delta());
+                
+                if(this.enemyPhaseTimer.delta() < 0){
+                    console.log("Drawing enemy modal");
+                    this.enemyPhaseModal.draw(0, 250);
+                }
+                if(this.phaseTimer.delta() > 0){
+                    console.log("Clearing battle state");
+                    this.battleState = null;
+                    this.displayedEnemyPhaseModal = true;
+                }
+            }
+
 
             if(typeof this.getEntityByName('btn_item_a0') && this.battleState === 'trading'){
                 a = this.units[this.activeUnit];

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -212,6 +212,7 @@ ig.module(
         weaponModal:        new ig.Image('media/gui/weapon_bonus_modal.png'  ),
         battleSummaryModal: new ig.Image('media/gui/battle_summary_modal.png'),
         playerPhaseModal:   new ig.Image('media/gui/player_phase.png'        ),
+        enemyPhaseModal:    new ig.Image('media/gui/enemy_phase.png'        ),
 
         init: function() {
             // Bind keys to game actions
@@ -327,8 +328,10 @@ ig.module(
                            // 'trade': selecting friendly unit to trade
                            // 'trading': trading with friendly unit in progress
                            // 'stats': viewing selected unit stat screen
-                           // 'phase': displaying player/enemy phase modal
-        displayedTurnModal: false, // did we display the phase modal?
+                           // 'player_phase': displaying player phase modal
+                           // 'enemy_phase': displaying enemy phase modal
+        displayedPlayerPhaseModal: false, // did we display the player phase modal?
+        displayedEnemyPhaseModal: false, // did we display the enemy phase modal? 
         units: [], // All units participating on battlefield
         activeUnit: 0, // Controlling unit
 
@@ -509,8 +512,8 @@ ig.module(
             var i, slot;
 
             // Have we displayed the player phase modal for the beginning of the turn?
-            if(this.displayedTurnModal === false){
-                this.battleState = 'phase';
+            if(this.displayedPlayerPhaseModal === false){
+                this.battleState = 'player_phase';
             }
 
             // Handle unit movement order
@@ -523,7 +526,7 @@ ig.module(
                 if(this.units[this.activeUnit] instanceof ig.global.EntityHero) {
                     this.turn_counter++;
                     // A new turn is starting, so we need to re-draw the "Player Phase" modal. 
-                    this.displayedTurnModal = false;
+                    this.displayedPlayerPhaseModal = false;
                     // Reset the timer which governs how long the modal is displayed. 
                     this.phaseTimer.reset();
                     console.log('Battle currently in turn ' + this.turn_counter);
@@ -1846,7 +1849,7 @@ ig.module(
 
             // We haven't displayed the phase modal for this turn
             
-            if(this.battleState === 'phase' && this.displayedTurnModal === false){
+            if(this.battleState === 'player_phase' && this.displayedPlayerPhaseModal === false){
                 // Timer is running, draw modal
                 if(this.phaseTimer.delta() < 0){
                     this.playerPhaseModal.draw(0, 250);
@@ -1854,7 +1857,7 @@ ig.module(
                 if(this.phaseTimer.delta() > 0){
                     // We finished drawing, reset states
                     this.battleState = null;
-                    this.displayedTurnModal = true;
+                    this.displayedPlayerPhaseModal = true;
                     // Reset the timer for the next time
                 }
             }

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -508,11 +508,9 @@ ig.module(
 
             var i, slot;
 
-
+            // Have we displayed the player phase modal for the beginning of the turn?
             if(this.displayedTurnModal === false){
                 this.battleState = 'phase';
-                //console.log("Haven't moved anyone yet");
-                console.log(this.battleState);
             }
 
             // Handle unit movement order
@@ -1849,14 +1847,11 @@ ig.module(
             // We haven't displayed the phase modal for this turn
             
             if(this.battleState === 'phase' && this.displayedTurnModal === false){
-                console.log(this.phaseTimer.delta());
                 // Timer is running, draw modal
                 if(this.phaseTimer.delta() < 0){
-                    console.log("Timer is running");
                     this.playerPhaseModal.draw(0, 250);
                 }
                 if(this.phaseTimer.delta() > 0){
-                    console.log("MEOW");
                     // We finished drawing, reset states
                     this.battleState = null;
                     this.displayedTurnModal = true;

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -406,7 +406,6 @@ ig.module(
 
             // Initialize timers
             this.atkAnimTimer = new ig.Timer();
-            this.phaseTimer = new ig.Timer(3); // Set a timer of 3 seconds
 
             this.screenFadeOut = new ig.ScreenFader({
                 fade: 'out',
@@ -507,13 +506,6 @@ ig.module(
             this.parent();
 
             var i, slot;
-
-            // Check how many units have moved for this turn
-            var units_moved = 0;
-            for(u = 0; u < this.units.length; u++) {
-                if(this.units[u].turnUsed)
-                    units_moved++;
-            }
 
             if(units_moved === 0 && this.displayedTurnModal === false){
                 this.battleState = 'phase';
@@ -1849,6 +1841,7 @@ ig.module(
             var a, t;
 
             // We haven't displayed the phase modal for this turn
+            /*
             if(this.battleState === 'phase' && this.displayedTurnModal === false){
                 // Timer is running, draw modal
                 if(this.phaseTimer.delta() < 0){
@@ -1861,7 +1854,7 @@ ig.module(
                     // Reset the timer for the next time
                     this.phaseTimer.reset();
                 }
-            }
+            }*/
 
             if(typeof this.getEntityByName('btn_item_a0') && this.battleState === 'trading'){
                 a = this.units[this.activeUnit];

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -406,6 +406,7 @@ ig.module(
 
             // Initialize timers
             this.atkAnimTimer = new ig.Timer();
+            this.phaseTimer = new ig.Timer(1);
 
             this.screenFadeOut = new ig.ScreenFader({
                 fade: 'out',
@@ -507,7 +508,8 @@ ig.module(
 
             var i, slot;
 
-            if(units_moved === 0 && this.displayedTurnModal === false){
+
+            if(this.displayedTurnModal === false){
                 this.battleState = 'phase';
                 //console.log("Haven't moved anyone yet");
                 console.log(this.battleState);
@@ -522,6 +524,8 @@ ig.module(
                 // Increase turn counter if active unit is main player (before main player moves)
                 if(this.units[this.activeUnit] instanceof ig.global.EntityHero) {
                     this.turn_counter++;
+                    this.displayedTurnModal = false;
+                    this.phaseTimer.reset();
                     console.log('Battle currently in turn ' + this.turn_counter);
                 }
 
@@ -1841,20 +1845,22 @@ ig.module(
             var a, t;
 
             // We haven't displayed the phase modal for this turn
-            /*
+            
             if(this.battleState === 'phase' && this.displayedTurnModal === false){
+                console.log(this.phaseTimer.delta());
                 // Timer is running, draw modal
                 if(this.phaseTimer.delta() < 0){
+                    console.log("Timer is running");
                     this.playerPhaseModal.draw(0, 250);
                 }
                 if(this.phaseTimer.delta() > 0){
+                    console.log("MEOW");
                     // We finished drawing, reset states
                     this.battleState = null;
                     this.displayedTurnModal = true;
                     // Reset the timer for the next time
-                    this.phaseTimer.reset();
                 }
-            }*/
+            }
 
             if(typeof this.getEntityByName('btn_item_a0') && this.battleState === 'trading'){
                 a = this.units[this.activeUnit];

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -211,6 +211,7 @@ ig.module(
         terrainModal:       new ig.Image('media/gui/terrainModal.png'        ),
         weaponModal:        new ig.Image('media/gui/weapon_bonus_modal.png'  ),
         battleSummaryModal: new ig.Image('media/gui/battle_summary_modal.png'),
+        playerPhaseModal:   new ig.Image('media/gui/player_phase.png'        ),
 
         init: function() {
             // Bind keys to game actions
@@ -326,6 +327,8 @@ ig.module(
                            // 'trade': selecting friendly unit to trade
                            // 'trading': trading with friendly unit in progress
                            // 'stats': viewing selected unit stat screen
+                           // 'phase': displaying player/enemy phase modal
+        displayedTurnModal: false, // did we display the phase modal?
         units: [], // All units participating on battlefield
         activeUnit: 0, // Controlling unit
 
@@ -403,6 +406,7 @@ ig.module(
 
             // Initialize timers
             this.atkAnimTimer = new ig.Timer();
+            this.phaseTimer = new ig.Timer(3); // Set a timer of 3 seconds
 
             this.screenFadeOut = new ig.ScreenFader({
                 fade: 'out',
@@ -504,6 +508,19 @@ ig.module(
 
             var i, slot;
 
+            // Check how many units have moved for this turn
+            var units_moved = 0;
+            for(u = 0; u < this.units.length; u++) {
+                if(this.units[u].turnUsed)
+                    units_moved++;
+            }
+
+            if(units_moved === 0 && this.displayedTurnModal === false){
+                this.battleState = 'phase';
+                //console.log("Haven't moved anyone yet");
+                console.log(this.battleState);
+            }
+
             // Handle unit movement order
             if(this.units[this.activeUnit].turnUsed) {
                 var u;
@@ -558,6 +575,7 @@ ig.module(
                     if(this.units[u].turnUsed)
                         units_moved++;
                 }
+
 
                 // If all units have moved for this turn, set all alive units to be able to move again
                 if(units_moved === this.units.length) {
@@ -1830,6 +1848,21 @@ ig.module(
 
             var a, t;
 
+            // We haven't displayed the phase modal for this turn
+            if(this.battleState === 'phase' && this.displayedTurnModal === false){
+                // Timer is running, draw modal
+                if(this.phaseTimer.delta() < 0){
+                    this.playerPhaseModal.draw(0, 250);
+                }
+                if(this.phaseTimer.delta() > 0){
+                    // We finished drawing, reset states
+                    this.battleState = null;
+                    this.displayedTurnModal = true;
+                    // Reset the timer for the next time
+                    this.phaseTimer.reset();
+                }
+            }
+
             if(typeof this.getEntityByName('btn_item_a0') && this.battleState === 'trading'){
                 a = this.units[this.activeUnit];
                 t = this.targetedUnit;
@@ -2332,7 +2365,7 @@ ig.module(
             this.screenFadeIn = new ig.ScreenFader({
                 fade: 'in',
                 speed: 1.5,
-                callback: function() { ig.system.setGame(ig.CutScene); },
+                callback: function() { ig.system.setGame(ig.BattleMode); },
                 delayBefore: 1,
                 delayAfter: 1
             });


### PR DESCRIPTION
This pull request fixes issue #79 . Clicking on an enemy during the player's turn will not perma-lock the menu. This pull request also contains work in progress code towards implementing player/enemy turn modals (commented out). 

UPDATE: This pull request also fixes issue #80, player units can no longer stack on each other. 

UPDATE 2: This pull request now implements displaying the player phase modal (enemy phase modal still needs to be hooked). Here are the new changes:

* The player is locked from moving any units until the player phase modal has finished displaying (currently set to display for one second). 
* The active unit's movement display is also disabled until the player phase modal has finished displaying.
* Every time the player begins a new turn, the player phase modal will display.

This feature gives some clear separation to the gameplay, and helps the player intuitively know when they can and cannot move their units. I am currently working on displaying the enemy phase modal as well, but this code can be folded in at your own discretion and I can send a separate pull request if needed when that feature is complete. 

UPDATE 3: This pull request now implements the enemy phase modal too, but it currently does not display for the proper time. The enemies will not move until the modal is done being displayed (as expected), but the modal does not appear for the time set. Perhaps @chessmasterhong could look into this before merging? 
