### PR TITLE
Resolving issue #82 and #83

### DIFF
--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -2017,7 +2017,7 @@ ig.module(
                         }
 
                         // Press enter to close the status screen.
-                        if(ig.input.state('menu')) {
+                        if(ig.input.state('escape')) {
                             this.battleState = null;
                         }
             }

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -14,7 +14,7 @@
 ig.global.gameState = null;
 ig.global.tilesize = 32;
 //ig.global.game_pos = {map: null, x: null, y: null};
-ig.global.encounter = {zone: 0, spawn_min: 1, spawn_max: 1};
+ig.global.encounter = {zone: 0, spawn_min: 2, spawn_max: 2};
 ig.global.levels = [];
 ig.global.party = [];
 
@@ -514,6 +514,7 @@ ig.module(
             // Have we displayed the player phase modal for the beginning of the turn?
             if(this.units[this.activeUnit].unitType === 'player' && this.displayedPlayerPhaseModal === false) {
                 this.battleState = 'player_phase';
+                this.displayedEnemyPhaseModal = false;
             }
 
             if(this.units[this.activeUnit].unitType === 'enemy' && this.displayedEnemyPhaseModal === false) {
@@ -542,7 +543,7 @@ ig.module(
 
                 if(this.units[this.activeUnit].unitType === 'enemy') {
                     // A new turn is starting, we need to re-draw the "Enemy phase" modal
-                    this.displayedEnemyPhaseModal = false;
+                    // this.displayedEnemyPhaseModal = false;
 
                     // Reset the timer which governs how long the enemy phase modal was displayed
                     this.enemyPhaseTimer.reset();


### PR DESCRIPTION
This pull request resolves issue #83. Also, instead of closing the stats screen using `ENTER`, the player can now only use `ESC` to exit out of the menu, as expected for consistency. 

UPDATE: This pull request also fixes the bug with the enemy phase modal respawning each time an individual enemy moves. 