### PR TITLE
Fixing issue #85, #87

### DIFF
--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -246,16 +246,18 @@ ig.module(
 
                                 // Wait for user's input (mouse)
                                 // Also, we check if the selected tile doesn't have a unit on it
-                                if(this.pointer.isLeftClicking && ig.game.hoveredUnit === null && ig.game.displayedPlayerPhaseModal === true) {
-                                    // console.log(ig.game.hoveredUnit);
-                                    // Check if pointer is within this unit's reachable distance this turn
-                                    var unit_pos = ig.global.alignToGrid(this.pos.x + ig.global.tilesize / 2, this.pos.y + ig.global.tilesize / 2);
-                                    var ptr_pos = ig.global.alignToGrid(this.pointer.pos.x, this.pointer.pos.y);
-                                    var d = Math.abs((unit_pos.x - ptr_pos.x) + (unit_pos.y - ptr_pos.y));
-                                    if(d <= Math.round(this.maxMovement) && ig.game.clickedUnit === this) {
-                                        // Align pointer's position to grid and set as destination
-                                        this.destination = ig.global.alignToGrid(this.pointer.pos.x, this.pointer.pos.y);
-                                        this.getPath(this.destination.x, this.destination.y, false, this.entitiesAvoid, this.entitiesIgnore);
+                                if(this.pointer.isLeftClicking && ig.game.displayedPlayerPhaseModal === true) {
+                                    if(ig.game.hoveredUnit === this || ig.game.hoveredUnit === null){
+                                        // console.log(ig.game.hoveredUnit);
+                                        // Check if pointer is within this unit's reachable distance this turn
+                                        var unit_pos = ig.global.alignToGrid(this.pos.x + ig.global.tilesize / 2, this.pos.y + ig.global.tilesize / 2);
+                                        var ptr_pos = ig.global.alignToGrid(this.pointer.pos.x, this.pointer.pos.y);
+                                        var d = Math.abs((unit_pos.x - ptr_pos.x) + (unit_pos.y - ptr_pos.y));
+                                        if(d <= Math.round(this.maxMovement) && ig.game.clickedUnit === this) {
+                                            // Align pointer's position to grid and set as destination
+                                            this.destination = ig.global.alignToGrid(this.pointer.pos.x, this.pointer.pos.y);
+                                            this.getPath(this.destination.x, this.destination.y, false, this.entitiesAvoid, this.entitiesIgnore);
+                                        }
                                     }
                                 }
 

--- a/lib/game/entities/misc/pointer.js
+++ b/lib/game/entities/misc/pointer.js
@@ -101,9 +101,9 @@ ig.module(
             this.parent(other);
 
             // User is clicking and the 'other' entity and has a clicked() method
-            if(this.isLeftClicking && typeof other.leftClicked === 'function' && other.unitType !== 'enemy')
+            if(this.isLeftClicking && typeof other.leftClicked === 'function')
                 other.leftClicked();
-            if(this.isRightClicking && typeof other.rightClicked === 'function' && other.unitType !== 'enemy')
+            if(this.isRightClicking && typeof other.rightClicked === 'function')
                 other.rightClicked();
         }
     }); // End EntityPointer

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -1423,7 +1423,8 @@ ig.module(
             }
 
             // Bring up stats screen
-            if(ig.input.pressed('SHIFT') && this.hoveredUnit !== null && this.units[this.activeUnit].unitType === 'player' && this.units[this.activeUnit].vel.x === 0 && this.units[this.activeUnit].vel.y === 0) {
+            if(ig.input.pressed('SHIFT') && this.hoveredUnit !== null && this.units[this.activeUnit].unitType === 'player' && this.units[this.activeUnit].vel.x === 0 && this.units[this.activeUnit].vel.y === 0
+                    && this.clickedUnit != null) {
                 // Storing the hovered unit within another variable prevents a few bugs, such as:
                 //  * After bringing up the status screen, if the player presses "shift" after moving the cursor, this.hoveredUnit would be null.
                 //  * Prevents bugs when closing the status screen.
@@ -1864,11 +1865,9 @@ ig.module(
 
             var a, t;
 
-            // We haven't displayed the phase modal for this turn
-
+            // We haven't displayed the player phase modal for this turn
             if(this.battleState === 'player_phase' && this.displayedPlayerPhaseModal === false) {
                 // Timer is running, draw modal
-                // console.log(this.phaseTimer.delta());
                 if(this.phaseTimer.delta() < 0) {
                     this.playerPhaseModal.draw(0, 250);
                 }
@@ -1879,15 +1878,12 @@ ig.module(
                 }
             }
 
+            // We haven't displayed the enemy phase modal for this turn
             if(this.battleState === 'enemy_phase' && this.displayedEnemyPhaseModal === false) {
-                // console.log(this.enemyPhaseTimer.delta());
-
                 if(this.enemyPhaseTimer.delta() < 0) {
-                    console.log("Drawing enemy modal");
                     this.enemyPhaseModal.draw(0, 250);
                 }
                 if(this.enemyPhaseTimer.delta() > 0) {
-                    console.log("Clearing battle state");
                     this.battleState = null;
                     this.displayedEnemyPhaseModal = true;
                 }


### PR DESCRIPTION
This pull request fixes issue #85. This pull request also fixes issue #87, which prevented the player from attacking enemies.

Currently:

1. Clicking on an enemy unit while trying to move should not bring up the menu.
2. Player should not be able to move on top of another unit (no unit stacking)
3. Player can choose to move to the spot it is currently on. 

NOTE: Please test this in any way possible to see if any bugs have arisen due to these changes.  Messing around randomly by clicking an enemy, then trying to move in to attack sometimes does not work. It's hard to re-create this, so I haven't nailed down why this happens. 

UPDATE: Upon messing around with various actions, I believe the problem is that if two enemies spawn on top of each other, there is no way to attack. I haven't been able to find any bugs with the features this pull request adds, though. This needs to be confirmed. 