### PR TITLE
Intermediate work on fixing issue #50

### DIFF
--- a/lib/game/entities/abstractities/base_enemy.js
+++ b/lib/game/entities/abstractities/base_enemy.js
@@ -689,6 +689,17 @@ ig.module(
             this.parent();
             this.turnUsed = true;
             console.log(this.name + ' has been defeated.');
+            /* The enemy kill method gets called two ways. 
+             *  1. Enemy is the attacker, and gets killed in counter attack.
+             *      - In this case, enemy is the active unit
+             *  2. Enemy is the defender, and gets killed by an attacker
+             *      - In this case, enemy is the targeted unit
+            */      
+            // CASE 1: Enemy is the active unit and is the attacker
+            //  - Enemy attacks, gets killed in counterattack
+            
+            ig.game.units.splice(ig.game.units.indexOf(this), 1);
+            
         }
     });
 });

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -732,7 +732,6 @@ ig.module(
 
             if(this.health > this.health_max)
                 this.health = this.health_max;
-
             //this.hpBarTimer.reset();
             console.log(from.name + ' attacks and inflicts ' + amount + ' damage to ' + this.name + '!');
         }, // End receiveDamage method
@@ -740,6 +739,8 @@ ig.module(
         kill: function() {
             this.parent();
             this.turnUsed = true;
+            // Remove the targeted unit
+            ig.game.units.splice(ig.game.units.indexOf(this), 1);
             console.log(this.name + ' has been defeated.');
         } // End kill method
     });


### PR DESCRIPTION
This pull request has a partial implementation to fix issue #50. Upon death, the unit in question is correctly removed from the game world. However, there are two cases where this fails:

1. Enemy attacks player, and enemy dies in counter-attack. If there are any other enemies on the map, the enemy turn will end. This is probably because the main loop in `main.js` doesn't recognize there are more enemies?
2. The same thing happens on the other end. If a player attacks an enemy and dies in the counter-attack, if there are more players, then the player turn will end.

I opened this pull request in the hopes that @chessmasterhong could see how these edge cases can be fixed? 

Another way I contemplated fixing this is that if that unit is dead, put a `dead` flag on them. Allow any units to be able to move on top of a dead unit and occupy their space. This works in all cases, a player can then move on that space and things will work fine. At least, I think so because it seems that dead enemies are removed once the turn ends. I'm not sure yet, but we'd preferably want to do the first implementation. 