### PR TITLE
Implemented shop enhancements

### DIFF
--- a/lib/game/entities/abstractities/base_enemy.js
+++ b/lib/game/entities/abstractities/base_enemy.js
@@ -277,7 +277,7 @@ ig.module(
         },
 
         leftClicked: function() {
-            if(ig.game.battleState !== 'trading' && this._killed === false) {
+            if(ig.game.battleState !== 'trading' && this._killed === false && ig.game.battleState !== 'shopping' && ig.game.battleState !== 'buying' && ig.game.battleState !== 'selling') {
                 ig.game.clickedUnit = this;
                 ig.game.targetedUnit = this;
             }

--- a/lib/game/entities/menus/button_shop_buy.js
+++ b/lib/game/entities/menus/button_shop_buy.js
@@ -13,6 +13,8 @@ ig.module(
     'use strict';
 
     ig.global.EntityButton_shop_buy = ig.Button.extend({
+        animSheet: new ig.AnimationSheet('media/gui/transparentbutton.png', 100, 32),
+        font: new ig.Font('media/fonts/verdana_20.font.png',  { fontColor: '#E5E5E5' }),
         name: 'btn_shop_buy',
         text: ['Buy'],
 

--- a/lib/game/entities/menus/button_shop_confirm_buy.js
+++ b/lib/game/entities/menus/button_shop_confirm_buy.js
@@ -1,0 +1,52 @@
+/**
+ *  button_shop_confirm_buy.js
+ *  -----
+ */
+
+ig.module(
+    'game.entities.menus.button_shop_confirm_buy'
+)
+.requires(
+    'plugins.button.button'
+)
+.defines(function() {
+    'use strict';
+
+    ig.global.EntityButton_shop_confirm_buy = ig.Button.extend({
+        animSheet: new ig.AnimationSheet('media/gui/transparentbutton.png', 100, 32),
+        font: new ig.Font('media/fonts/verdana_20.font.png',  { fontColor: '#E5E5E5' }),
+        name: 'btn_shop_confirm_buy',
+        text: ['Yes'],
+
+        pressedUp: function() {
+            ig.game.boughtItemTimer.reset();
+            ig.game.boughtItem = true; 
+            ig.game.boughtItemName = ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex].name;
+            var slot = ig.game.getFreeSlot(ig.game.units[ig.game.activeUnit]);
+            if(slot !== null) {
+                if(ig.global.gold >= ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex].cost) {
+                    ig.global.gold -= ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex].cost;
+                    ig.game.units[ig.game.activeUnit].item[slot] = ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex];
+                    ig.game.units[ig.game.activeUnit].item_uses[slot] = ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex].uses;
+                    ig.game.recomputeStats(ig.game.units[ig.game.activeUnit]);
+                } else {
+                    console.log('You do not have enough money!');
+                }
+            } else {
+                console.log('Inventory full!');
+            }
+
+            ig.game.selectedShopItemIndex = null;
+            ig.game.confirmBuy = false;
+
+            ig.global.killAllButtons(ig.Button);
+            if(typeof ig.game.getEntityByName('btn_shop_exit') === 'undefined') {
+                ig.game.spawnEntity(ig.global.EntityButton_shop_exit, ig.game.screen.x + 264, ig.game.screen.y + 132);
+                ig.game.spawnEntity(ig.global.EntityButton_shop_buy, ig.game.screen.x + 164, ig.game.screen.y + 132);
+                ig.game.spawnEntity(ig.global.EntityButton_shop_sell, ig.game.screen.x + 364, ig.game.screen.y + 132);
+            }
+
+            
+        }
+    });
+});

--- a/lib/game/entities/menus/button_shop_confirm_buy.js
+++ b/lib/game/entities/menus/button_shop_confirm_buy.js
@@ -30,9 +30,13 @@ ig.module(
                     ig.game.units[ig.game.activeUnit].item_uses[slot] = ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex].uses;
                     ig.game.recomputeStats(ig.game.units[ig.game.activeUnit]);
                 } else {
+                    ig.game.lowMoney = true; 
+                    ig.game.lowMoneyTimer.reset();
                     console.log('You do not have enough money!');
                 }
             } else {
+                ig.game.fullInventory = true; 
+                ig.game.fullInventoryTimer.reset();
                 console.log('Inventory full!');
             }
 

--- a/lib/game/entities/menus/button_shop_confirm_buy.js
+++ b/lib/game/entities/menus/button_shop_confirm_buy.js
@@ -42,15 +42,9 @@ ig.module(
 
             ig.game.selectedShopItemIndex = null;
             ig.game.confirmBuy = false;
+            ig.game.buySellConfirmed = false;
 
-            ig.global.killAllButtons(ig.Button);
-            if(typeof ig.game.getEntityByName('btn_shop_exit') === 'undefined') {
-                ig.game.spawnEntity(ig.global.EntityButton_shop_exit, ig.game.screen.x + 264, ig.game.screen.y + 132);
-                ig.game.spawnEntity(ig.global.EntityButton_shop_buy, ig.game.screen.x + 164, ig.game.screen.y + 132);
-                ig.game.spawnEntity(ig.global.EntityButton_shop_sell, ig.game.screen.x + 364, ig.game.screen.y + 132);
-            }
-
-            
+            ig.global.killAllButtons(ig.Button);            
         }
     });
 });

--- a/lib/game/entities/menus/button_shop_confirm_sell.js
+++ b/lib/game/entities/menus/button_shop_confirm_sell.js
@@ -1,0 +1,46 @@
+/**
+ *  button_shop_confirm_sell.js
+ *  -----
+ */
+
+ig.module(
+    'game.entities.menus.button_shop_confirm_sell'
+)
+.requires(
+    'plugins.button.button'
+)
+.defines(function() {
+    'use strict';
+
+    ig.global.EntityButton_shop_confirm_sell = ig.Button.extend({
+        animSheet: new ig.AnimationSheet('media/gui/transparentbutton.png', 100, 32),
+        font: new ig.Font('media/fonts/verdana_20.font.png',  { fontColor: '#E5E5E5' }),
+        name: 'btn_shop_confirm_sell',
+        text: ['Yes'],
+
+        pressedUp: function() {
+            console.log("clicked");
+            ig.game.soldItemTimer.reset();
+            ig.game.soldItem = true;
+            ig.game.soldItemName = ig.game.units[ig.game.activeUnit].item[ig.game.units[ig.game.activeUnit].selectedItemIndex].name;
+            ig.global.gold += ig.game.units[ig.game.activeUnit].item[ig.game.units[ig.game.activeUnit].selectedItemIndex].cost;
+            // Set sold item to be null
+            ig.game.units[ig.game.activeUnit].item[ig.game.units[ig.game.activeUnit].selectedItemIndex] = null;
+            // Redraw the player's inventory
+            for(i = 0; i < ig.game.units[ig.game.activeUnit].item.length; i++) {
+                // console.log('mememem');
+                ig.game.getEntityByName('btn_item_a' + i).kill();
+            }
+
+            ig.game.units[ig.game.activeUnit].selectedItemIndex = null;
+            ig.game.confirmSell = false; 
+
+            ig.global.killAllButtons(ig.Button);
+            if(typeof ig.game.getEntityByName('btn_shop_exit') === 'undefined') {
+                ig.game.spawnEntity(ig.global.EntityButton_shop_exit, ig.game.screen.x + 264, ig.game.screen.y + 132);
+                ig.game.spawnEntity(ig.global.EntityButton_shop_buy, ig.game.screen.x + 164, ig.game.screen.y + 132);
+                ig.game.spawnEntity(ig.global.EntityButton_shop_sell, ig.game.screen.x + 364, ig.game.screen.y + 132);
+            }
+        }
+    });
+});

--- a/lib/game/entities/menus/button_shop_confirm_sell.js
+++ b/lib/game/entities/menus/button_shop_confirm_sell.js
@@ -33,13 +33,9 @@ ig.module(
 
             ig.game.units[ig.game.activeUnit].selectedItemIndex = null;
             ig.game.confirmSell = false; 
+            ig.game.buySellConfirmed = false;
 
             ig.global.killAllButtons(ig.Button);
-            if(typeof ig.game.getEntityByName('btn_shop_exit') === 'undefined') {
-                ig.game.spawnEntity(ig.global.EntityButton_shop_exit, ig.game.screen.x + 264, ig.game.screen.y + 132);
-                ig.game.spawnEntity(ig.global.EntityButton_shop_buy, ig.game.screen.x + 164, ig.game.screen.y + 132);
-                ig.game.spawnEntity(ig.global.EntityButton_shop_sell, ig.game.screen.x + 364, ig.game.screen.y + 132);
-            }
         }
     });
 });

--- a/lib/game/entities/menus/button_shop_confirm_sell.js
+++ b/lib/game/entities/menus/button_shop_confirm_sell.js
@@ -19,7 +19,6 @@ ig.module(
         text: ['Yes'],
 
         pressedUp: function() {
-            console.log("clicked");
             ig.game.soldItemTimer.reset();
             ig.game.soldItem = true;
             ig.game.soldItemName = ig.game.units[ig.game.activeUnit].item[ig.game.units[ig.game.activeUnit].selectedItemIndex].name;

--- a/lib/game/entities/menus/button_shop_deny_buy.js
+++ b/lib/game/entities/menus/button_shop_deny_buy.js
@@ -1,0 +1,34 @@
+/**
+ *  button_shop_deny_buy.js
+ *  -----
+ */
+
+ig.module(
+    'game.entities.menus.button_shop_deny_buy'
+)
+.requires(
+    'plugins.button.button'
+)
+.defines(function() {
+    'use strict';
+
+    ig.global.EntityButton_shop_deny_buy = ig.Button.extend({
+        animSheet: new ig.AnimationSheet('media/gui/transparentbutton.png', 100, 32),
+        font: new ig.Font('media/fonts/verdana_20.font.png',  { fontColor: '#E5E5E5' }),
+        name: 'btn_shop_deny_buy',
+        text: ['No'],
+
+        pressedUp: function() {
+            ig.game.confirmBuy = false;
+            ig.game.selectedShopItemIndex = null;
+            ig.global.killAllButtons(ig.Button);
+            if(typeof ig.game.getEntityByName('btn_shop_exit') === 'undefined') {
+                ig.game.spawnEntity(ig.global.EntityButton_shop_exit, ig.game.screen.x + 264, ig.game.screen.y + 132);
+                ig.game.spawnEntity(ig.global.EntityButton_shop_buy, ig.game.screen.x + 164, ig.game.screen.y + 132);
+                ig.game.spawnEntity(ig.global.EntityButton_shop_sell, ig.game.screen.x + 364, ig.game.screen.y + 132);
+            }  
+
+            
+        }
+    });
+});

--- a/lib/game/entities/menus/button_shop_deny_sell.js
+++ b/lib/game/entities/menus/button_shop_deny_sell.js
@@ -1,0 +1,33 @@
+/**
+ *  button_shop_deny_sell.js
+ *  -----
+ */
+
+ig.module(
+    'game.entities.menus.button_shop_deny_sell'
+)
+.requires(
+    'plugins.button.button'
+)
+.defines(function() {
+    'use strict';
+
+    ig.global.EntityButton_shop_deny_sell = ig.Button.extend({
+        animSheet: new ig.AnimationSheet('media/gui/transparentbutton.png', 100, 32),
+        font: new ig.Font('media/fonts/verdana_20.font.png',  { fontColor: '#E5E5E5' }),
+        name: 'btn_shop_deny_sell',
+        text: ['No'],
+
+        pressedUp: function() {
+            ig.game.confirmSell = false;
+            ig.game.units[ig.game.activeUnit].selectedItemIndex = null;
+            ig.game.units[ig.game.activeUnit].item[ig.game.units[ig.game.activeUnit].selectedItemIndex] = null;
+            ig.global.killAllButtons(ig.Button);
+            if(typeof ig.game.getEntityByName('btn_shop_exit') === 'undefined') {
+                ig.game.spawnEntity(ig.global.EntityButton_shop_exit, ig.game.screen.x + 264, ig.game.screen.y + 132);
+                ig.game.spawnEntity(ig.global.EntityButton_shop_buy, ig.game.screen.x + 164, ig.game.screen.y + 132);
+                ig.game.spawnEntity(ig.global.EntityButton_shop_sell, ig.game.screen.x + 364, ig.game.screen.y + 132);
+            }
+        }
+    });
+});

--- a/lib/game/entities/menus/button_shop_exit.js
+++ b/lib/game/entities/menus/button_shop_exit.js
@@ -13,6 +13,8 @@ ig.module(
     'use strict';
 
     ig.global.EntityButton_shop_exit = ig.Button.extend({
+        animSheet: new ig.AnimationSheet('media/gui/transparentbutton.png', 100, 32),
+        font: new ig.Font('media/fonts/verdana_20.font.png',  { fontColor: '#E5E5E5' }),
         name: 'btn_shop_exit',
         text: ['Exit'],
 

--- a/lib/game/entities/menus/button_shop_item.js
+++ b/lib/game/entities/menus/button_shop_item.js
@@ -15,8 +15,9 @@ ig.module(
     ig.global.EntityButton_shop_item = ig.Button.extend({
         index: 0,
 
-        animSheet: new ig.AnimationSheet('media/gui/bignewMenu.png', 200, 32),
-        size: {x: 200, y: 32},
+        animSheet: new ig.AnimationSheet('media/gui/transparentbutton.png', 385, 32),
+        size: {x: 385, y: 32},
+        font: new ig.Font('media/fonts/verdana_20.font.png',  { fontColor: '#E5E5E5' }),
 
         init: function(x, y, settings) {
             this.parent(x, y, settings);

--- a/lib/game/entities/menus/button_shop_sell.js
+++ b/lib/game/entities/menus/button_shop_sell.js
@@ -13,6 +13,8 @@ ig.module(
     'use strict';
 
     ig.global.EntityButton_shop_sell = ig.Button.extend({
+        animSheet: new ig.AnimationSheet('media/gui/transparentbutton.png', 100, 32),
+        font: new ig.Font('media/fonts/verdana_20.font.png',  { fontColor: '#E5E5E5' }),
         name: 'btn_shop_sell',
         text: ['Sell'],
 

--- a/lib/game/entities/menus/button_transparent.js
+++ b/lib/game/entities/menus/button_transparent.js
@@ -1,0 +1,36 @@
+/**
+ *  button_transparent.js
+ *  -----
+ */
+
+ig.module(
+    'game.entities.menus.button_transparent'
+)
+.requires(
+    'plugins.button.button'
+)
+.defines(function() {
+    'use strict';
+
+    ig.global.EntityButton_transparent = ig.Button.extend({
+        index: 0,
+
+        animSheet: new ig.AnimationSheet('media/gui/transparentbutton.png', 385, 32),
+        size: {x: 385, y: 32},
+        font: new ig.Font('media/fonts/verdana_20.font.png',  { fontColor: '#E5E5E5' }),
+
+        init: function(x, y, settings) {
+            this.parent(x, y, settings);
+
+            this.name = 'btn_item_a' + this.index;
+            this.iconLeft = ig.game.units[ig.game.activeUnit].item[this.index] !== null ? ig.game.units[ig.game.activeUnit].item[this.index].icon : null;
+            this.text = [ig.game.units[ig.game.activeUnit].item[this.index] !== null ? ig.game.units[ig.game.activeUnit].item[this.index].name : '----'];
+            this.textRight = [ig.game.units[ig.game.activeUnit].item[this.index] !== null ? ig.game.units[ig.game.activeUnit].item_uses[this.index] : ''];
+        },
+
+        pressedUp: function() {
+            // Determine which item is being selected.
+            ig.game.units[ig.game.activeUnit].selectedItemIndex = this.index;
+        }
+    });
+});

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -351,6 +351,8 @@ ig.module(
         soldItemName: null,
         confirmSell: false,
         confirmBuy: false, 
+        lowMoney: false,
+        fullInventory: false, 
 
         // Unit statistics
         numPlayers: 0,
@@ -471,6 +473,8 @@ ig.module(
             this.expTimer = new ig.Timer(this.exp_time);
             this.boughtItemTimer = new ig.Timer(1.5);
             this.soldItemTimer = new ig.Timer(1.5);
+            this.lowMoneyTimer = new ig.Timer(1.5);
+            this.fullInventoryTimer = new ig.Timer(1.5);
 
             this.screenFadeOut = new ig.ScreenFader({
                 fade: 'out',
@@ -2199,13 +2203,31 @@ ig.module(
                     this.fontContent20.draw('Buy ' + ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex].name + ' for ' + ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex].cost + '?', 175, 50);
                 }
 
-                if(!this.boughtItem && !this.confirmBuy){
+                if(this.lowMoney){
+                    if(this.lowMoneyTimer.delta() < 0){
+                        this.fontContent20.draw('You do not have enough money!', 175, 50);
+                    }
+                    if(this.lowMoneyTimer.delta() > 0){
+                        this.lowMoney = false; 
+                    }
+                }
+
+                if(this.fullInventory){
+                    if(this.fullInventoryTimer.delta() < 0){
+                        this.fontContent20.draw('Inventory full!', 175, 50);
+                    }
+                    if(this.fullInventoryTimer.delta() > 0){
+                        this.fullInventory = false; 
+                    }
+                }
+
+                if(!this.boughtItem && !this.confirmBuy && !this.lowMoney && !this.fullInventory){
                     this.fontContent20.draw('Click an item to purchase it.', 175, 50);
                 }
 
                 this.font30.default.draw(ig.global.gold, 505, 155);
                 if(this.boughtItemTimer.delta() < 0){
-                    if(this.boughtItem){
+                    if(this.boughtItem && !this.confirmBuy && !this.lowMoney && !this.fullInventory){
                         this.fontContent20.draw('Thank you for purchasing ' + this.boughtItemName + '.', 175, 50);
                     }
                 }

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -1512,7 +1512,6 @@ ig.module(
                     }
 
                     if(this.battleState === 'selling') {
-                        console.log("Selling");
 
                         if(typeof this.getEntityByName('btn_shop_item_0') !== 'undefined') {
                             for(i = 0; i < this.itemCatalog.shop1.length; i++) {
@@ -1531,8 +1530,7 @@ ig.module(
                             if(this.units[this.activeUnit].selectedItemIndex !== null) {
                                 if(this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex] !== null) {
                                     this.confirmSell = true; 
-                                    // Spawn yes button here
-                                    // ig.global.killAllButtons(ig.Button);
+
                                     if(typeof this.getEntityByName('btn_shop_exit') !== 'undefined') {
                                         this.getEntityByName('btn_shop_exit').kill();
                                     }
@@ -1550,7 +1548,6 @@ ig.module(
                     }
 
                     if(this.battleState === 'buying') {
-                        console.log('buying');
 
                         if(typeof this.getEntityByName('btn_item_a0') !== 'undefined') {
                             for(i = 0; i< this.units[this.activeUnit].item.length; i++) {

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -254,8 +254,8 @@ ig.module(
             //ig.input.bind(ig.KEY.CTRL ,       'CTRL'  ); // Left/Right Control
 
             // Load and configure background music
-            ig.music.add('media/sounds/bgm/awakening.ogg', 'credits');
-            ig.music.add('media/sounds/bgm/czhang/FireEmblem_-_Companions_CZ_Rearrange.ogg', 'companions');
+            // ig.music.add('media/sounds/bgm/awakening.ogg', 'credits');
+            // ig.music.add('media/sounds/bgm/czhang/FireEmblem_-_Companions_CZ_Rearrange.ogg', 'companions');
         } // End init method
     }); // End ig.BaseGame
 
@@ -462,8 +462,8 @@ ig.module(
             this.levelUpModalTimer = new ig.Timer(1.5); // How long to display level up modal
             this.levelUpBonusTimer = new ig.Timer(1.0); // How long between displaying each +1 bonus
             this.expTimer = new ig.Timer(this.exp_time);
-            this.boughtItemTimer = new ig.Timer(1.0);
-            this.soldItemTimer = new ig.Timer(2.0);
+            this.boughtItemTimer = new ig.Timer(1.5);
+            this.soldItemTimer = new ig.Timer(1.5);
 
             this.screenFadeOut = new ig.ScreenFader({
                 fade: 'out',
@@ -1488,7 +1488,6 @@ ig.module(
             } else {
                 if(this.battleState === 'shopping' || this.battleState === 'buying' || this.battleState === 'selling') {
                     // Spawn shop overlay and buttons, if necessary
-
                     if(this.battleState === 'shopping') {
                         if(typeof this.getEntityByName('shop') === 'undefined') {
                             this.spawnEntity(ig.global.EntityOverlay_shop, 0, 0);
@@ -1516,30 +1515,35 @@ ig.module(
                             }
                         }
 
-                        if(this.units[this.activeUnit].selectedItemIndex !== null) {
-                            if(this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex] !== null) {
-                                this.soldItemName = this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].name;
-                                // Check amount of gold before selling an item
-                                console.log(ig.global.gold);
-                                // Increase party's gold by item amount
-                                ig.global.gold += this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].cost;
-                                // Check amount of gold after selling an item
-                                console.log(ig.global.gold);
-                                // Set sold item to be null
-                                this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex] = null;
-                                // Redraw the player's inventory
-                                for(i = 0; i < this.units[this.activeUnit].item.length; i++) {
-                                    console.log('mememem');
-                                    this.getEntityByName('btn_item_a' + i).kill();
-                                }
+                        if(this.soldItem === false){
+                            if(this.units[this.activeUnit].selectedItemIndex !== null) {
+                                if(this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex] !== null) {
+                                    this.soldItemTimer.reset();
+                                    this.soldItem = true;
+                                    this.soldItemName = this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].name;
+                                    // Check amount of gold before selling an item
+                                    //console.log(ig.global.gold);
+                                    // Increase party's gold by item amount
+                                    ig.global.gold += this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].cost;
+                                    // Check amount of gold after selling an item
+                                    //console.log(ig.global.gold);
+                                    // Set sold item to be null
+                                    this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex] = null;
+                                    // Redraw the player's inventory
+                                    for(i = 0; i < this.units[this.activeUnit].item.length; i++) {
+                                        // console.log('mememem');
+                                        this.getEntityByName('btn_item_a' + i).kill();
+                                    }
 
-                                this.units[this.activeUnit].selectedItemIndex = null;
+                                    this.units[this.activeUnit].selectedItemIndex = null;
+                                }
                             }
                         }
                     }
 
                     if(this.battleState === 'buying') {
                         console.log('buying');
+
                         if(typeof this.getEntityByName('btn_item_a0') !== 'undefined') {
                             for(i = 0; i< this.units[this.activeUnit].item.length; i++) {
                                 this.getEntityByName('btn_item_a' + i).kill();
@@ -1551,24 +1555,28 @@ ig.module(
                                 this.spawnEntity(ig.global.EntityButton_shop_item, this.screen.x + 160, this.screen.y + (i + 1) * 32 + 200, {index: i});
                             }
                         }
-
-                        if(this.selectedShopItemIndex !== null) {
-                            slot = this.getFreeSlot(this.units[this.activeUnit]);
-                            if(slot !== null) {
-                                if(ig.global.gold >= this.itemCatalog.shop1[this.selectedShopItemIndex].cost) {
-                                    ig.global.gold -= this.itemCatalog.shop1[this.selectedShopItemIndex].cost;
-                                    this.units[this.activeUnit].item[slot] = this.itemCatalog.shop1[this.selectedShopItemIndex];
-                                    this.units[this.activeUnit].item_uses[slot] = this.itemCatalog.shop1[this.selectedShopItemIndex].uses;
-                                    this.recomputeStats(this.units[this.activeUnit]);
+                        if(this.boughtItem === false){
+                            if(this.selectedShopItemIndex !== null) {
+                                this.boughtItemTimer.reset();
+                                this.boughtItem = true; 
+                                this.boughtItemName = this.itemCatalog.shop1[this.selectedShopItemIndex].name;
+                                slot = this.getFreeSlot(this.units[this.activeUnit]);
+                                if(slot !== null) {
+                                    if(ig.global.gold >= this.itemCatalog.shop1[this.selectedShopItemIndex].cost) {
+                                        ig.global.gold -= this.itemCatalog.shop1[this.selectedShopItemIndex].cost;
+                                        this.units[this.activeUnit].item[slot] = this.itemCatalog.shop1[this.selectedShopItemIndex];
+                                        this.units[this.activeUnit].item_uses[slot] = this.itemCatalog.shop1[this.selectedShopItemIndex].uses;
+                                        this.recomputeStats(this.units[this.activeUnit]);
+                                    } else {
+                                        console.log('You do not have enough money!');
+                                    }
                                 } else {
-                                    console.log('You do not have enough money!');
+                                    console.log('Inventory full!');
                                 }
-                            } else {
-                                console.log('Inventory full!');
-                            }
 
-                            this.selectedShopItemIndex = null;
-                        } // End if(this.selectedShopItemIndex !== null)
+                                this.selectedShopItemIndex = null;
+                            } // End if(this.selectedShopItemIndex !== null)
+                        }
                     } // End if(this.battleState === 'buying')
                 } // End if(this.battleState === 'shopping || this.battleState === 'buying')
             } // End Else
@@ -2183,12 +2191,36 @@ ig.module(
             if(this.battleState === 'shopping'){
                 this.fontContent20.draw('Welcome! Are you buying or selling?', 175, 50);
                 this.font30.default.draw(ig.global.gold, 505, 155);
-            } else if (this.battleState === 'buying'){
-                this.fontContent20.draw('Click an item to purchase it.', 175, 50);
+            }
+
+            if (this.battleState === 'buying'){
+                if(!this.boughtItem){
+                    this.fontContent20.draw('Click an item to purchase it.', 175, 50);
+                }
                 this.font30.default.draw(ig.global.gold, 505, 155);
-            } else if (this.battleState === 'selling'){
-                this.fontContent20.draw('Click an item to sell it.', 175, 50);
+                if(this.boughtItemTimer.delta() < 0){
+                    if(this.boughtItem){
+                        this.fontContent20.draw('Thank you for purchasing ' + this.boughtItemName + '.', 175, 50);
+                    }
+                }
+                if(this.boughtItemTimer.delta() > 0){
+                    this.boughtItem = false;
+                }
+            }
+
+            if (this.battleState === 'selling'){
+                if(!this.soldItem){
+                    this.fontContent20.draw('Click an item to sell it.', 175, 50);
+                }
                 this.font30.default.draw(ig.global.gold, 505, 155);
+                if(this.soldItemTimer.delta() < 0){
+                    if(this.soldItem){
+                        this.fontContent20.draw('Thank you for selling ' + this.soldItemName + '.', 175, 50);
+                    }
+                }
+                if(this.soldItemTimer.delta() > 0){
+                    this.soldItem = false;
+                }
             }
 
             // We haven't displayed the player phase modal for this turn

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -353,6 +353,7 @@ ig.module(
         confirmBuy: false, 
         lowMoney: false,
         fullInventory: false, 
+        buySellConfirmed: false, 
 
         // Unit statistics
         numPlayers: 0,
@@ -1512,6 +1513,13 @@ ig.module(
                     }
 
                     if(this.battleState === 'selling') {
+                        if(this.soldItemTimer.delta() > 0 && !this.buySellConfirmed){
+                            if(typeof ig.game.getEntityByName('btn_shop_exit') === 'undefined') {
+                                ig.game.spawnEntity(ig.global.EntityButton_shop_exit, ig.game.screen.x + 264, ig.game.screen.y + 132);
+                                ig.game.spawnEntity(ig.global.EntityButton_shop_buy, ig.game.screen.x + 164, ig.game.screen.y + 132);
+                                ig.game.spawnEntity(ig.global.EntityButton_shop_sell, ig.game.screen.x + 364, ig.game.screen.y + 132);
+                            }
+                        }
 
                         if(typeof this.getEntityByName('btn_shop_item_0') !== 'undefined') {
                             for(i = 0; i < this.itemCatalog.shop1.length; i++) {
@@ -1529,7 +1537,8 @@ ig.module(
                         if(this.soldItem === false){
                             if(this.units[this.activeUnit].selectedItemIndex !== null) {
                                 if(this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex] !== null) {
-                                    this.confirmSell = true; 
+                                    this.confirmSell = true;
+                                    this.buySellConfirmed = true;  
 
                                     if(typeof this.getEntityByName('btn_shop_exit') !== 'undefined') {
                                         this.getEntityByName('btn_shop_exit').kill();
@@ -1549,6 +1558,14 @@ ig.module(
 
                     if(this.battleState === 'buying') {
 
+                        if(this.boughtItemTimer.delta() > 0 && !this.buySellConfirmed){
+                            if(typeof ig.game.getEntityByName('btn_shop_exit') === 'undefined') {
+                                ig.game.spawnEntity(ig.global.EntityButton_shop_exit, ig.game.screen.x + 264, ig.game.screen.y + 132);
+                                ig.game.spawnEntity(ig.global.EntityButton_shop_buy, ig.game.screen.x + 164, ig.game.screen.y + 132);
+                                ig.game.spawnEntity(ig.global.EntityButton_shop_sell, ig.game.screen.x + 364, ig.game.screen.y + 132);
+                            }
+                        }
+
                         if(typeof this.getEntityByName('btn_item_a0') !== 'undefined') {
                             for(i = 0; i< this.units[this.activeUnit].item.length; i++) {
                                 this.getEntityByName('btn_item_a' + i).kill();
@@ -1564,6 +1581,7 @@ ig.module(
                         if(this.boughtItem === false){
                             if(this.selectedShopItemIndex !== null) {
                                 this.confirmBuy = true;
+                                this.buySellConfirmed = true; 
                                 if(typeof this.getEntityByName('btn_shop_exit') !== 'undefined') {
                                     this.getEntityByName('btn_shop_exit').kill();
                                 }

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -148,6 +148,7 @@ ig.module(
     'game.entities.menus.button_shop_sell',
     'game.entities.menus.button_shop_exit',
     'game.entities.menus.button_seize',
+    'game.entities.menus.button_transparent',
 
     // Levels/Maps
     //'game.levels.demo',
@@ -1511,7 +1512,7 @@ ig.module(
 
                         if(typeof this.getEntityByName('btn_item_a0') === 'undefined') {
                             for(i = 0; i < this.units[this.activeUnit].item.length; i++) {
-                                this.spawnEntity(ig.global.EntityButton_trade_item_active, this.screen.x + 160, this.screen.y + (i + 1) * 32 + 200, {index: i});
+                                this.spawnEntity(ig.global.EntityButton_transparent, this.screen.x + 150, this.screen.y + (i + 1) * 32 + 200, {index: i});
                             }
                         }
 
@@ -1521,12 +1522,7 @@ ig.module(
                                     this.soldItemTimer.reset();
                                     this.soldItem = true;
                                     this.soldItemName = this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].name;
-                                    // Check amount of gold before selling an item
-                                    //console.log(ig.global.gold);
-                                    // Increase party's gold by item amount
                                     ig.global.gold += this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].cost;
-                                    // Check amount of gold after selling an item
-                                    //console.log(ig.global.gold);
                                     // Set sold item to be null
                                     this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex] = null;
                                     // Redraw the player's inventory
@@ -1552,7 +1548,7 @@ ig.module(
 
                         if(typeof this.getEntityByName('btn_shop_item_0') === 'undefined') {
                             for(i = 0; i < this.itemCatalog.shop1.length; i++) {
-                                this.spawnEntity(ig.global.EntityButton_shop_item, this.screen.x + 160, this.screen.y + (i + 1) * 32 + 200, {index: i});
+                                this.spawnEntity(ig.global.EntityButton_shop_item, this.screen.x + 150, this.screen.y + (i + 1) * 32 + 200, {index: i});
                             }
                         }
                         if(this.boughtItem === false){

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -1549,8 +1549,12 @@ ig.module(
                                     if(typeof this.getEntityByName('btn_shop_sell') !== 'undefined') {
                                         this.getEntityByName('btn_shop_sell').kill();
                                     }
-                                    this.spawnEntity(ig.global.EntityButton_shop_confirm_sell, this.screen.x + 164, this.screen.y + 132);
-                                    this.spawnEntity(ig.global.EntityButton_shop_deny_sell, this.screen.x + 264, this.screen.y + 132);
+                                    if(typeof this.getEntityByName('btn_shop_confirm_sell') === 'undefined'){
+                                        this.spawnEntity(ig.global.EntityButton_shop_confirm_sell, this.screen.x + 164, this.screen.y + 132);
+                                    }
+                                    if(typeof this.getEntityByName('btn_shop_deny_sell') === 'undefined'){
+                                        this.spawnEntity(ig.global.EntityButton_shop_deny_sell, this.screen.x + 264, this.screen.y + 132);
+                                    }
                                 }
                             }
                         }
@@ -1591,8 +1595,12 @@ ig.module(
                                 if(typeof this.getEntityByName('btn_shop_sell') !== 'undefined') {
                                     this.getEntityByName('btn_shop_sell').kill();
                                 }
-                                this.spawnEntity(ig.global.EntityButton_shop_confirm_buy, this.screen.x + 164, this.screen.y + 132);
-                                this.spawnEntity(ig.global.EntityButton_shop_deny_buy, this.screen.x + 264, this.screen.y + 132);
+                                if(typeof this.getEntityByName('btn_shop_confirm_buy') === 'undefined'){
+                                    this.spawnEntity(ig.global.EntityButton_shop_confirm_buy, this.screen.x + 164, this.screen.y + 132);
+                                }
+                                if(typeof this.getEntityByName('btn_shop_deny_buy') === 'undefined'){
+                                    this.spawnEntity(ig.global.EntityButton_shop_deny_buy, this.screen.x + 264, this.screen.y + 132);
+                                }
 
                                 
                             } // End if(this.selectedShopItemIndex !== null)

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -151,6 +151,8 @@ ig.module(
     'game.entities.menus.button_transparent',
     'game.entities.menus.button_shop_confirm_sell',
     'game.entities.menus.button_shop_deny_sell',
+    'game.entities.menus.button_shop_confirm_buy',
+    'game.entities.menus.button_shop_deny_buy',
 
     // Levels/Maps
     //'game.levels.demo',
@@ -257,8 +259,8 @@ ig.module(
             //ig.input.bind(ig.KEY.CTRL ,       'CTRL'  ); // Left/Right Control
 
             // Load and configure background music
-            // ig.music.add('media/sounds/bgm/awakening.ogg', 'credits');
-            // ig.music.add('media/sounds/bgm/czhang/FireEmblem_-_Companions_CZ_Rearrange.ogg', 'companions');
+            ig.music.add('media/sounds/bgm/awakening.ogg', 'credits');
+            ig.music.add('media/sounds/bgm/czhang/FireEmblem_-_Companions_CZ_Rearrange.ogg', 'companions');
         } // End init method
     }); // End ig.BaseGame
 
@@ -1557,26 +1559,23 @@ ig.module(
                                 this.spawnEntity(ig.global.EntityButton_shop_item, this.screen.x + 150, this.screen.y + (i + 1) * 32 + 200, {index: i});
                             }
                         }
+
                         if(this.boughtItem === false){
                             if(this.selectedShopItemIndex !== null) {
-                                this.boughtItemTimer.reset();
-                                this.boughtItem = true; 
-                                this.boughtItemName = this.itemCatalog.shop1[this.selectedShopItemIndex].name;
-                                slot = this.getFreeSlot(this.units[this.activeUnit]);
-                                if(slot !== null) {
-                                    if(ig.global.gold >= this.itemCatalog.shop1[this.selectedShopItemIndex].cost) {
-                                        ig.global.gold -= this.itemCatalog.shop1[this.selectedShopItemIndex].cost;
-                                        this.units[this.activeUnit].item[slot] = this.itemCatalog.shop1[this.selectedShopItemIndex];
-                                        this.units[this.activeUnit].item_uses[slot] = this.itemCatalog.shop1[this.selectedShopItemIndex].uses;
-                                        this.recomputeStats(this.units[this.activeUnit]);
-                                    } else {
-                                        console.log('You do not have enough money!');
-                                    }
-                                } else {
-                                    console.log('Inventory full!');
+                                this.confirmBuy = true;
+                                if(typeof this.getEntityByName('btn_shop_exit') !== 'undefined') {
+                                    this.getEntityByName('btn_shop_exit').kill();
                                 }
+                                if(typeof this.getEntityByName('btn_shop_buy') !== 'undefined') {
+                                    this.getEntityByName('btn_shop_buy').kill();
+                                }
+                                if(typeof this.getEntityByName('btn_shop_sell') !== 'undefined') {
+                                    this.getEntityByName('btn_shop_sell').kill();
+                                }
+                                this.spawnEntity(ig.global.EntityButton_shop_confirm_buy, this.screen.x + 164, this.screen.y + 132);
+                                this.spawnEntity(ig.global.EntityButton_shop_deny_buy, this.screen.x + 264, this.screen.y + 132);
 
-                                this.selectedShopItemIndex = null;
+                                
                             } // End if(this.selectedShopItemIndex !== null)
                         }
                     } // End if(this.battleState === 'buying')
@@ -2196,15 +2195,21 @@ ig.module(
             }
 
             if (this.battleState === 'buying'){
-                if(!this.boughtItem){
+                if(this.confirmBuy){
+                    this.fontContent20.draw('Buy ' + ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex].name + ' for ' + ig.game.itemCatalog.shop1[ig.game.selectedShopItemIndex].cost + '?', 175, 50);
+                }
+
+                if(!this.boughtItem && !this.confirmBuy){
                     this.fontContent20.draw('Click an item to purchase it.', 175, 50);
                 }
+
                 this.font30.default.draw(ig.global.gold, 505, 155);
                 if(this.boughtItemTimer.delta() < 0){
                     if(this.boughtItem){
                         this.fontContent20.draw('Thank you for purchasing ' + this.boughtItemName + '.', 175, 50);
                     }
                 }
+
                 if(this.boughtItemTimer.delta() > 0){
                     this.boughtItem = false;
                 }
@@ -2218,12 +2223,14 @@ ig.module(
                 if(!this.soldItem && !this.confirmSell){
                     this.fontContent20.draw('Click an item to sell it.', 175, 50);
                 }
+
                 this.font30.default.draw(ig.global.gold, 505, 155);
                 if(this.soldItemTimer.delta() < 0){
                     if(this.soldItem){
                         this.fontContent20.draw('Thank you for selling ' + this.soldItemName + '.', 175, 50);
                     }
                 }
+
                 if(this.soldItemTimer.delta() > 0){
                     this.soldItem = false;
                 }

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -149,6 +149,8 @@ ig.module(
     'game.entities.menus.button_shop_exit',
     'game.entities.menus.button_seize',
     'game.entities.menus.button_transparent',
+    'game.entities.menus.button_shop_confirm_sell',
+    'game.entities.menus.button_shop_deny_sell',
 
     // Levels/Maps
     //'game.levels.demo',
@@ -345,6 +347,8 @@ ig.module(
         boughtItemName: null,
         soldItem: false,
         soldItemName: null,
+        confirmSell: false,
+        confirmBuy: false, 
 
         // Unit statistics
         numPlayers: 0,
@@ -1516,22 +1520,24 @@ ig.module(
                             }
                         }
 
+
                         if(this.soldItem === false){
                             if(this.units[this.activeUnit].selectedItemIndex !== null) {
                                 if(this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex] !== null) {
-                                    this.soldItemTimer.reset();
-                                    this.soldItem = true;
-                                    this.soldItemName = this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].name;
-                                    ig.global.gold += this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].cost;
-                                    // Set sold item to be null
-                                    this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex] = null;
-                                    // Redraw the player's inventory
-                                    for(i = 0; i < this.units[this.activeUnit].item.length; i++) {
-                                        // console.log('mememem');
-                                        this.getEntityByName('btn_item_a' + i).kill();
+                                    this.confirmSell = true; 
+                                    // Spawn yes button here
+                                    // ig.global.killAllButtons(ig.Button);
+                                    if(typeof this.getEntityByName('btn_shop_exit') !== 'undefined') {
+                                        this.getEntityByName('btn_shop_exit').kill();
                                     }
-
-                                    this.units[this.activeUnit].selectedItemIndex = null;
+                                    if(typeof this.getEntityByName('btn_shop_buy') !== 'undefined') {
+                                        this.getEntityByName('btn_shop_buy').kill();
+                                    }
+                                    if(typeof this.getEntityByName('btn_shop_sell') !== 'undefined') {
+                                        this.getEntityByName('btn_shop_sell').kill();
+                                    }
+                                    this.spawnEntity(ig.global.EntityButton_shop_confirm_sell, this.screen.x + 164, this.screen.y + 132);
+                                    this.spawnEntity(ig.global.EntityButton_shop_deny_sell, this.screen.x + 264, this.screen.y + 132);
                                 }
                             }
                         }
@@ -2205,7 +2211,11 @@ ig.module(
             }
 
             if (this.battleState === 'selling'){
-                if(!this.soldItem){
+                if(this.confirmSell){
+                    this.fontContent20.draw('Sell ' + this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].name + ' for ' + this.units[this.activeUnit].item[this.units[this.activeUnit].selectedItemIndex].cost + '?', 175, 50);
+                }
+
+                if(!this.soldItem && !this.confirmSell){
                     this.fontContent20.draw('Click an item to sell it.', 175, 50);
                 }
                 this.font30.default.draw(ig.global.gold, 505, 155);

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -345,15 +345,15 @@ ig.module(
         tempUnit: null,
 
         // Shop properties
-        boughtItem: false,
-        boughtItemName: null,
-        soldItem: false,
-        soldItemName: null,
-        confirmSell: false,
-        confirmBuy: false, 
-        lowMoney: false,
-        fullInventory: false, 
-        buySellConfirmed: false, 
+        boughtItem: false, // Did we buy an item?
+        boughtItemName: null, // What is the item we bought?
+        soldItem: false, // Did we sell an item?
+        soldItemName: null, // What is the item we sold?
+        confirmSell: false, // Used for handling text display when waiting for user to press yes/no on sell screen
+        confirmBuy: false,  // Used for handling text display when waiting for user to press yes/no on buy screen
+        lowMoney: false, // Can we not afford an item? Used to display the proper text when buying an item we can't afford
+        fullInventory: false, // Do we have a full inventory? Used to display the proper text when buying an item with full inventory
+        buySellConfirmed: false, // Used for hiding/displaying the buy/sell/exit button until enough time has passed
 
         // Unit statistics
         numPlayers: 0,


### PR DESCRIPTION
You will need the latest media from https://bitbucket.org/chessmasterhong/wateremblem-media/downloads to run this. 

This pull request addresses issue #133. On top of enhancing the shop system, I went ahead and also implemented a confirmation system too. Clicking an item will prompt the player with a `Yes` or `No` option, both for buy and sell. Almost all messages are on a timer, to make it feel a little more real. 
Also covered cases where the player cannot afford to buy the item in question, or has a full inventory - the appropriate text is displayed on a timer. 

EDIT: I've also added some new properties that space out messages in the shop. For example, purchasing an item will:

* Show a message saying you have purchased `<item>`, then after 1.5 seconds, it will re-display the buy/sell/exit buttons. 

This behavior occurs for both buying and selling, to add some flow and separation between buying, selling, waiting for the user to press yes/no to confirm their choice, etc. As of now, the shop system fully resembles a shop in an actual Fire Emblem game (or any game with a shop, in general). 