### PR TITLE
Adding sound effects, several bug fixes

### DIFF
--- a/lib/game/entities/abstractities/base_enemy.js
+++ b/lib/game/entities/abstractities/base_enemy.js
@@ -698,6 +698,7 @@ ig.module(
             var firsthalf = ig.game.unitStats.slice(0, ig.game.unitStats.indexOf(this));
             var secondhalf = ig.game.unitStats.slice(ig.game.unitStats.indexOf(this) + 1, ig.game.unitStats.length);
             ig.game.unitStats = firsthalf.concat(secondhalf);
+            ig.game.numEnemies -= 1; 
             console.log(this.name + ' has been defeated.');
         }
     });

--- a/lib/game/entities/abstractities/base_enemy.js
+++ b/lib/game/entities/abstractities/base_enemy.js
@@ -278,7 +278,6 @@ ig.module(
 
         leftClicked: function() {
             if(ig.game.battleState !== 'trading' && (ig.game.units[ig.game.activeUnit].unitType !== 'player' || ig.game.battleState === 'attack' ) && this._killed === false && ig.game.battleState !== 'shopping' && ig.game.battleState !== 'buying' && ig.game.battleState !== 'selling') {
-                console.log('clicked');
                 ig.game.clickedUnit = this;
                 ig.game.targetedUnit = this;
             }

--- a/lib/game/entities/abstractities/base_enemy.js
+++ b/lib/game/entities/abstractities/base_enemy.js
@@ -277,7 +277,8 @@ ig.module(
         },
 
         leftClicked: function() {
-            if(ig.game.battleState !== 'trading' && this._killed === false && ig.game.battleState !== 'shopping' && ig.game.battleState !== 'buying' && ig.game.battleState !== 'selling') {
+            if(ig.game.battleState !== 'trading' && (ig.game.units[ig.game.activeUnit].unitType !== 'player' || ig.game.battleState === 'attack' ) && this._killed === false && ig.game.battleState !== 'shopping' && ig.game.battleState !== 'buying' && ig.game.battleState !== 'selling') {
+                console.log('clicked');
                 ig.game.clickedUnit = this;
                 ig.game.targetedUnit = this;
             }

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -503,7 +503,6 @@ ig.module(
 
         leftClicked: function() {
             if(ig.game.battleState !== 'trading' && this._killed === false && ig.game.battleState !== 'shopping' && ig.game.battleState !== 'buying' && ig.game.battleState !== 'selling' && ig.game.battleState !== 'stats' && ig.game.battleState !== 'objective') {
-                console.log("hi");
                 ig.game.clickedUnit = this;
                 ig.game.targetedUnit = this;
             }

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -763,6 +763,7 @@ ig.module(
             var firsthalf = ig.game.unitStats.slice(0, ig.game.unitStats.indexOf(this));
             var secondhalf = ig.game.unitStats.slice(ig.game.unitStats.indexOf(this) + 1, ig.game.unitStats.length);
             ig.game.unitStats = firsthalf.concat(secondhalf);
+            ig.game.numPlayers -= 1; 
             console.log(this.name + ' has been defeated.');
         } // End kill method
     });

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -763,7 +763,7 @@ ig.module(
             var firsthalf = ig.game.unitStats.slice(0, ig.game.unitStats.indexOf(this));
             var secondhalf = ig.game.unitStats.slice(ig.game.unitStats.indexOf(this) + 1, ig.game.unitStats.length);
             ig.game.unitStats = firsthalf.concat(secondhalf);
-            ig.game.numPlayers -= 1; 
+            ig.game.numPlayers -= 1;
             console.log(this.name + ' has been defeated.');
         } // End kill method
     });

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -502,7 +502,7 @@ ig.module(
         },
 
         leftClicked: function() {
-            if(ig.game.battleState !== 'trading' && this._killed === false && ig.game.battleState !== 'shopping' && ig.game.battleState !== 'buying' && ig.game.battleState !== 'selling') {
+            if(ig.game.battleState !== 'trading' && this._killed === false && ig.game.battleState !== 'shopping' && ig.game.battleState !== 'buying' && ig.game.battleState !== 'selling' && ig.game.battleState !== 'stats' && ig.game.battleState !== 'objective') {
                 console.log("hi");
                 ig.game.clickedUnit = this;
                 ig.game.targetedUnit = this;

--- a/lib/game/entities/abstractities/base_player.js
+++ b/lib/game/entities/abstractities/base_player.js
@@ -222,7 +222,7 @@ ig.module(
 
             if(ig.game.units[ig.game.activeUnit] === this) {
                 // Proceed with unit's action if unit's turn is not used and game is not displaying menu
-                if(!this.turnUsed && !ig.game.menuVisible) {
+                if(!this.turnUsed && !ig.game.menuVisible && ig.game.battleState !== 'objective' && ig.game.battleState !== 'stats') {
                     // Small timer to prevent instant unit movement (due to user input) when changing active unit to this unit
                     if(this.idleTimer.delta() > 0.2) {
                         // Update grid movement
@@ -503,6 +503,7 @@ ig.module(
 
         leftClicked: function() {
             if(ig.game.battleState !== 'trading' && this._killed === false && ig.game.battleState !== 'shopping' && ig.game.battleState !== 'buying' && ig.game.battleState !== 'selling') {
+                console.log("hi");
                 ig.game.clickedUnit = this;
                 ig.game.targetedUnit = this;
             }

--- a/lib/game/entities/animations/wyvernLord_battleanim.js
+++ b/lib/game/entities/animations/wyvernLord_battleanim.js
@@ -30,7 +30,7 @@ ig.module(
             this.addAnim('idle', 1, [0], true);
             this.anims.dodge   = new ig.Animation(this.animSheet,     0.07, [0], true);
             this.anims.attack0 = new ig.Animation(this.animSheet,     0.07, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9, 9, 9, 9, 9], true);
-            this.anims.attack1 = new ig.Animation(this.animSheet,     0.07, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36], true);
+            this.anims.attack1 = new ig.Animation(this.animSheet,     0.07, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 0], true);
             this.anims.crit0   = new ig.Animation(this.animSheetCrit, 0.07, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,24, 25, 26, 27, 27, 27, 27, 27], true);
             this.anims.crit1   = new ig.Animation(this.animSheetCrit, 0.07, [28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54], true);
         },

--- a/lib/game/entities/menus/button_shop_confirm_buy.js
+++ b/lib/game/entities/menus/button_shop_confirm_buy.js
@@ -39,7 +39,8 @@ ig.module(
                 ig.game.fullInventoryTimer.reset();
                 console.log('Inventory full!');
             }
-
+            ig.game.moneySFX.volume = 0.9;
+            ig.game.moneySFX.play();
             ig.game.selectedShopItemIndex = null;
             ig.game.confirmBuy = false;
             ig.game.buySellConfirmed = false;

--- a/lib/game/entities/menus/button_shop_confirm_sell.js
+++ b/lib/game/entities/menus/button_shop_confirm_sell.js
@@ -31,6 +31,8 @@ ig.module(
                 ig.game.getEntityByName('btn_item_a' + i).kill();
             }
 
+            ig.game.moneySFX.volume = 0.9;
+            ig.game.moneySFX.play();
             ig.game.units[ig.game.activeUnit].selectedItemIndex = null;
             ig.game.confirmSell = false; 
             ig.game.buySellConfirmed = false;

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -245,6 +245,7 @@ ig.module(
         critSFX:            new ig.Sound('media/sounds/sfx/crit.*'           ),
         deathSFX:           new ig.Sound('media/sounds/sfx/death.*'          ),
         nextTurnSFX:        new ig.Sound('media/sounds/sfx/nextturn.*'       ),
+        levelUpSFX:         new ig.Sound('media/sounds/sfx/levelup.*'        ),
 
         init: function() {
             // Bind keys to game actions
@@ -362,8 +363,10 @@ ig.module(
         fullInventory: false, // Do we have a full inventory? Used to display the proper text when buying an item with full inventory
         buySellConfirmed: false, // Used for hiding/displaying the buy/sell/exit button until enough time has passed
 
-        // Playing turn phase sound effect
+        // Sound effects controllers
         playingTurnSFX: false, 
+        playingLevelUpSFX: false, 
+
         // Unit statistics
         numPlayers: 0,
         numEnemies: 0,
@@ -2455,6 +2458,11 @@ ig.module(
                         // Display level up message
                         if(this.levelUpMessageTimer.delta() < 0){
                             this.levelUpMessage.draw(20, 200);
+                            if(!this.playingLevelUpSFX){
+                                this.playingLevelUpSFX = true;
+                                this.levelUpSFX.volume = 0.9;
+                                this.levelUpSFX.play();
+                            }
                         }
                         // Finished displaying level up message.
                         // Draw level up modal
@@ -2525,6 +2533,11 @@ ig.module(
                         // Display level up message
                         if(this.levelUpMessageTimer.delta() < 0){
                             this.levelUpMessage.draw(20, 200);
+                            if(!this.playingLevelUpSFX){
+                                this.playingLevelUpSFX = true;
+                                this.levelUpSFX.volume = 0.9;
+                                this.levelUpSFX.play();
+                            }
                         }
                         // Finished displaying level up message.
                         // Draw level up modal
@@ -2607,6 +2620,7 @@ ig.module(
                         this.units[this.activeUnit].levelUpBonuses.res = 0;
                         this.units[this.activeUnit].leveledUp = false;
                         this.battleState =  null;
+                        this.playingLevelUpSFX = false;
                         // If we need to discard an item due to full inventory...
                         if(this.item_drop !== null){
                             this.dropCheck();
@@ -2623,6 +2637,7 @@ ig.module(
                         this.targetedUnit.levelUpBonuses.def = 0;
                         this.targetedUnit.levelUpBonuses.res = 0;
                         this.targetedUnit.leveledUp = false;
+                        this.playingLevelUpSFX = false;
                         this.battleState =  null;
                         // If we need to discard an item due to full inventory...
                         if(this.item_drop !== null){

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -239,6 +239,12 @@ ig.module(
         levelUpBonus:       new ig.Image('media/gui/bonus.png'               ),
         expModal:           new ig.Image('media/gui/exp_modal.png'           ),
         objectiveModal:     new ig.Image('media/gui/objective.png'           ),
+        // expSFX:             new ig.Sound('media/sounds/sfx/experiencebar.*'  ),
+        hitSFX:             new ig.Sound('media/sounds/sfx/hit.*'            ),
+        missSFX:            new ig.Sound('media/sounds/sfx/attackmiss.*'     ),
+        critSFX:            new ig.Sound('media/sounds/sfx/crit.*'           ),
+        deathSFX:           new ig.Sound('media/sounds/sfx/death.*'          ),
+        nextTurnSFX:        new ig.Sound('media/sounds/sfx/nextturn.*'       ),
 
         init: function() {
             // Bind keys to game actions
@@ -261,6 +267,7 @@ ig.module(
             // Load and configure background music
             ig.music.add('media/sounds/bgm/awakening.ogg', 'credits');
             ig.music.add('media/sounds/bgm/czhang/FireEmblem_-_Companions_CZ_Rearrange.ogg', 'companions');
+            ig.music.volume = 0.3;
         } // End init method
     }); // End ig.BaseGame
 
@@ -355,6 +362,8 @@ ig.module(
         fullInventory: false, // Do we have a full inventory? Used to display the proper text when buying an item with full inventory
         buySellConfirmed: false, // Used for hiding/displaying the buy/sell/exit button until enough time has passed
 
+        // Playing turn phase sound effect
+        playingTurnSFX: false, 
         // Unit statistics
         numPlayers: 0,
         numEnemies: 0,
@@ -614,12 +623,22 @@ ig.module(
                 // this.freeCamera = false;
                 this.battleState = 'player_phase';
                 this.displayedEnemyPhaseModal = false;
+                if(!this.playingTurnSFX){
+                    this.playingTurnSFX = true;
+                    this.nextTurnSFX.volume = 0.9;
+                    this.nextTurnSFX.play();
+                }
             }
 
             if(this.units[this.activeUnit].unitType === 'enemy' && this.displayedEnemyPhaseModal === false) {
                 // console.log('Enemy is currently moving');
                 this.freeCamera = false;
                 this.battleState = 'enemy_phase';
+                if(!this.playingTurnSFX){
+                    this.playingTurnSFX = true;
+                    this.nextTurnSFX.volume = 0.9;
+                    this.nextTurnSFX.play();
+                }
             }
 
             // Handle unit movement order
@@ -997,6 +1016,8 @@ ig.module(
 
                                     // Active unit's attack hit
                                     console.log('Critical hit');
+                                    this.critSFX.volume = 0.9;
+                                    this.critSFX.play();
 
                                     this.screenshakeIntensity = 10;
 
@@ -1026,6 +1047,8 @@ ig.module(
                                     // Compute if active unit's attack hit or missed
                                     // Active unit's attack hit
                                     if(this.computeBattleNormalHitChance(this.units[this.activeUnit], this.targetedUnit) + this.weaponTriangle(this.units[this.activeUnit], this.targetedUnit) > Math.random() * 100) {
+                                        this.hitSFX.volume = 0.9;
+                                        this.hitSFX.play();
                                         console.log('Normal hit');
 
                                         this.screenshakeIntensity = 5;
@@ -1041,6 +1064,8 @@ ig.module(
                                         }
                                     // Active unit's attack missed
                                     } else {
+                                        this.missSFX.volume = 0.9;
+                                        this.missSFX.play();
                                         console.log('Attack missed');
 
                                         // Play target unit's dodge animation
@@ -1097,6 +1122,8 @@ ig.module(
 
                                     // Target unit's attack hit
                                     console.log('Critical hit');
+                                    this.critSFX.volume = 0.9;
+                                    this.critSFX.play();
 
                                     this.screenshakeIntensity = 10;
 
@@ -1127,7 +1154,8 @@ ig.module(
                                     // Target unit's attack hit
                                     if(this.computeBattleNormalHitChance(this.targetedUnit, this.units[this.activeUnit]) + this.weaponTriangle(this.targetedUnit, this.units[this.activeUnit]) > Math.random() * 100) {
                                         console.log('Normal hit');
-
+                                        this.hitSFX.volume = 0.9;
+                                        this.hitSFX.play();
                                         this.screenshakeIntensity = 5;
 
                                         // Compute damage
@@ -1141,6 +1169,8 @@ ig.module(
                                         }
                                     // Target unit's attack missed
                                     } else {
+                                        this.missSFX.volume = 0.9;
+                                        this.missSFX.play();
                                         console.log('Attack missed');
 
                                         // Play active unit's dodge animation
@@ -1208,6 +1238,8 @@ ig.module(
 
                                     // Active unit's attack hit
                                     console.log('Critical hit');
+                                    this.hitSFX.volume = 0.9;
+                                    this.hitSFX.play();
 
                                     this.screenshakeIntensity = 10;
 
@@ -1238,7 +1270,8 @@ ig.module(
                                     // Active unit's attack hit
                                     if(this.computeBattleNormalHitChance(this.units[this.activeUnit], this.targetedUnit) + this.weaponTriangle(this.units[this.activeUnit], this.targetedUnit) > Math.random() * 100) {
                                         console.log('Normal hit');
-
+                                        this.hitSFX.volume = 0.9;
+                                        this.hitSFX.play();
                                         this.screenshakeIntensity = 5;
 
                                         // Compute damage
@@ -1252,6 +1285,8 @@ ig.module(
                                         }
                                     // Active unit's attack missed
                                     } else {
+                                        this.missSFX.volume = 0.9;
+                                        this.missSFX.play();
                                         console.log('Attack missed');
 
                                         // Play target unit's dodge animation
@@ -1296,6 +1331,8 @@ ig.module(
 
                                     // Target unit's attack hit
                                     console.log('Critical hit');
+                                    this.critSFX.volume = 0.9;
+                                    this.critSFX.play();
 
                                     this.screenshakeIntensity = 10;
 
@@ -1326,7 +1363,8 @@ ig.module(
                                     // Target unit's attack hit
                                     if(this.computeBattleNormalHitChance(this.targetedUnit, this.units[this.activeUnit]) + this.weaponTriangle(this.targetedUnit, this.units[this.activeUnit]) > Math.random() * 100) {
                                         console.log('Normal hit');
-
+                                        this.hitSFX.volume = 0.9;
+                                        this.hitSFX.play();
                                         this.screenshakeIntensity = 5;
 
                                         // Compute damage
@@ -1340,6 +1378,8 @@ ig.module(
                                         }
                                     // Target unit's attack missed
                                     } else {
+                                        this.missSFX.volume = 0.9;
+                                        this.missSFX.play();
                                         console.log('Attack missed');
 
                                         // Play active unit's dodge animation
@@ -1363,9 +1403,13 @@ ig.module(
                     } else if(this.attackQueueIndex === 3) {
                         if(this.battleAnimStats.activeUnit.health <= 0) {
                             this.attackQueue[0].fade = true; // Set flag to fade away defeated active unit
+                            this.deathSFX.volume = 0.9;
+                            this.deathSFX.play();
                         }
                         if(this.battleAnimStats.targetedUnit.health <= 0) {
                             this.attackQueue[1].fade = true; // Set flag to fade away defeated target unit
+                            this.deathSFX.volume = 0.9;
+                            this.deathSFX.play();
                         }
 
                         // Upon death, enemy's equipped item transferred to player inventory, provided slots are available
@@ -2290,6 +2334,7 @@ ig.module(
                 if(this.phaseTimer.delta() > 0) {
                     // We finished drawing, reset states
                     this.battleState = null;
+                    this.playingTurnSFX = false; 
                     this.displayedPlayerPhaseModal = true;
                 }
             }
@@ -2301,6 +2346,7 @@ ig.module(
                 }
                 if(this.enemyPhaseTimer.delta() > 0) {
                     this.battleState = null;
+                    this.playingTurnSFX = false;
                     this.displayedEnemyPhaseModal = true;
                 }
             }
@@ -2351,12 +2397,14 @@ ig.module(
                             269 * ((expCurr % expNext) / expNext),
                             10
                         );
+                    // this.expSFX.volume = 0.9;
+                    // this.expSFX.play();
                     ig.system.context.closePath();
                     ig.system.context.fill();
 
                     // Numerical experience
                     this.font20.default.draw(Math.floor(expCurr % expNext), ig.system.width / 2 + 140, ig.system.height / 2 - 9);
-                } else if(this.expTimer.delta() > 1.5) {
+                } else if(this.expTimer.delta() > 1.0) {
                     // Did we level up?
                     if((this.units[this.activeUnit].unitType === 'player' && this.units[this.activeUnit].leveledUp === true) ||
                         (this.targetedUnit && this.targetedUnit.unitType === 'player' && this.targetedUnit.leveledUp === true))

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -246,6 +246,8 @@ ig.module(
         deathSFX:           new ig.Sound('media/sounds/sfx/death.*'          ),
         nextTurnSFX:        new ig.Sound('media/sounds/sfx/nextturn.*'       ),
         levelUpSFX:         new ig.Sound('media/sounds/sfx/levelup.*'        ),
+        clickSFX:           new ig.Sound('media/sounds/sfx/trimmedselect.*'  ),
+
 
         init: function() {
             // Bind keys to game actions
@@ -758,6 +760,8 @@ ig.module(
                             for(t = 0; t < this.attackTargets.length; t++) {
                                 if(this.targetedUnit === this.attackTargets[t].unit) {
                                     this.attackDistance = this.attackTargets[t].dist;
+                                    this.clickSFX.volume = 0.9;
+                                    this.clickSFX.play();
                                     this.fadeInToBattleAnim();
                                     this.battleState = 'battle_transitionIn';
                                     break;

--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -247,7 +247,7 @@ ig.module(
         nextTurnSFX:        new ig.Sound('media/sounds/sfx/nextturn.*'       ),
         levelUpSFX:         new ig.Sound('media/sounds/sfx/levelup.*'        ),
         clickSFX:           new ig.Sound('media/sounds/sfx/trimmedselect.*'  ),
-
+        moneySFX:           new ig.Sound('media/sounds/sfx/money.*'          ),
 
         init: function() {
             // Bind keys to game actions

--- a/lib/plugins/button/button.js
+++ b/lib/plugins/button/button.js
@@ -34,6 +34,7 @@ ig.module(
             letterSpacing: -1
         }),
         animSheet: new ig.AnimationSheet('media/gui/button.png', 100, 32),
+        clickSFX: new ig.Sound('media/sounds/sfx/trimmedselect.*'),
 
         state: 'idle',
 
@@ -152,7 +153,9 @@ ig.module(
         },
 
         pressedDown: function() {},
-        pressed: function() {},
+        pressed: function() {            
+            this.clickSFX.volume = 0.9;
+            this.clickSFX.play();},
         pressedUp: function() {},
 
         _inButton: function() {

--- a/lib/plugins/button/button.js
+++ b/lib/plugins/button/button.js
@@ -34,7 +34,7 @@ ig.module(
             letterSpacing: -1
         }),
         animSheet: new ig.AnimationSheet('media/gui/button.png', 100, 32),
-        clickSFX: new ig.Sound('media/sounds/sfx/trimmedselect.*'),
+        
 
         state: 'idle',
 
@@ -154,8 +154,9 @@ ig.module(
 
         pressedDown: function() {},
         pressed: function() {            
-            this.clickSFX.volume = 0.9;
-            this.clickSFX.play();},
+            ig.game.clickSFX.volume = 0.9;
+            ig.game.clickSFX.play();
+        },
         pressedUp: function() {},
 
         _inButton: function() {


### PR DESCRIPTION
To run this pull request, you will need the new media files from https://bitbucket.org/chessmasterhong/wateremblem-media/downloads

This pull request has the following changes:

* Subtracting number of player/enemy units upon defeat to keep the objective status screen up to date with the proper number of units.
* Fixed issue #143.
* Fixed issue #144.
* Fixed issue #145.
* Minor fix to Wyvern Lord battle animation.
* Added sound effect for when a successful hit occurs during battle.
* Added sound effect for when a miss occurs during battle.
* Added sound effect for when a button is clicked.
* Added sound effect for when an enemy is clicked to enter battle with.
* Added sound effect for critical hit in battle.
* Added sound effect when displaying player/enemy phase modal.
* Added sound effect when purchasing/selling items in the shop. 
* Added sound effect when enemy/player dies in battle.
* Added level up sound effect. 
* Using some musical editing as well as some flags to control when certain sound effects play, I was able to match up some sound effects with their exact display condition (for instance, the death sound effect will play as an enemy fades away, the player/enemy phase modal display is lined up with the sound effect). 

